### PR TITLE
fix:resolve jitter when stopping trajectory

### DIFF
--- a/aubo_driver/include/aubo_driver/aubo_driver.h
+++ b/aubo_driver/include/aubo_driver/aubo_driver.h
@@ -45,7 +45,7 @@
 #define AMAX 10000
 //#define JMAX 40000
 #define JMAX 40000
-
+#define STOP_DELAY_CLEAR_TIMES 10
 //#define LOG_INFO_DEBUG
 
 namespace aubo_driver
@@ -178,6 +178,8 @@ namespace aubo_driver
             int collision_class_;
             std_msgs::Int32MultiArray rib_status_;
             industrial_msgs::RobotStatus robot_status_;
+
+            int delay_clear_times;
     };
 }
 


### PR DESCRIPTION
When using move_group_interface.stop(),
the real robot will shake. This is a bug
in the aubo_driver, which has been fixed.